### PR TITLE
Aws task 7

### DIFF
--- a/authorization_service/src/handlers/basic-authorizer.ts
+++ b/authorization_service/src/handlers/basic-authorizer.ts
@@ -1,0 +1,76 @@
+import { APIGatewayAuthorizerResult, APIGatewayAuthorizerEvent, APIGatewayTokenAuthorizerEvent } from 'aws-lambda';
+
+const headers = { 
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Methods': 'GET, PUT, OPTIONS',
+  'Access-Control-Allow-Credentials': true,
+};
+
+function generatePolicy(principalId: string, effect: 'Allow' | 'Deny', resource: string): APIGatewayAuthorizerResult {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource,
+        },
+      ],
+    },
+  };
+}
+
+export const basicAuthorizerHandler = async (event: APIGatewayAuthorizerEvent): Promise<
+  APIGatewayAuthorizerResult | { statusCode: number; headers: Record<string, string | boolean>, body: string }> => {
+  try {
+    console.log('Authorization event:', event);
+
+    // Extract Authorization header
+    const authorizationHeader = (event as APIGatewayTokenAuthorizerEvent).authorizationToken;
+    if (!authorizationHeader) {
+      console.log('Missing Authorization header: ', event);
+      return {
+        statusCode: 401,
+        headers,
+        body: JSON.stringify({ message: 'Unauthorized' }),
+      };
+    }
+
+    const decodedToken = Buffer.from(authorizationHeader, 'base64').toString('utf-8');
+    const [username, password] = decodedToken.split(':'); // Parse `username:password`
+
+    if (!username || !password) {
+      console.log('Invalid token format: ', decodedToken);
+      return {
+        statusCode: 403,
+        headers,
+        body: JSON.stringify({ message: 'Access is denied' }),
+      };
+    }
+
+    const validUsername = process.env.AUTH_USERNAME || 'admin';
+    const validPassword = process.env.AUTH_PASSWORD || 'password123';
+
+    if (username !== validUsername || password !== validPassword) {
+      console.log('Invalid credentials: ', validUsername, validPassword);
+      return {
+        statusCode: 403,
+        headers,
+        body: JSON.stringify({ message: 'Access is denied' }),
+      };
+    }
+
+    return generatePolicy(username, 'Allow', event.methodArn);
+
+  } catch (error) {
+    console.error('Error validating Authorization:', error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ message: 'Internal Server Error' }),
+    };
+  }
+};

--- a/authorization_service/tsconfig.json
+++ b/authorization_service/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/authorization_service",
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "declaration": true,
+    "composite": true,
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 import 'dotenv/config';
 import 'source-map-support/register';
-import { ProductsStack, ImportStack, LayerStack } from './src';
+import { ProductsStack, ImportStack, LayerStack, AuthorizationStack } from './src';
 import { App } from 'aws-cdk-lib';
 
 const app = new App();
 
 const layerStack = new LayerStack(app, 'LayerStack', {
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.AWS_REGION },
+});
+
+new AuthorizationStack(app, 'AuthorizationServiceStack', layerStack, {
   env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.AWS_REGION },
 });
 

--- a/cdk/src/authorization.stack.ts
+++ b/cdk/src/authorization.stack.ts
@@ -1,5 +1,8 @@
 import {
+  aws_iam,
   aws_lambda,
+  CfnOutput,
+  Duration,
   Stack,
   StackProps
 } from 'aws-cdk-lib';
@@ -7,20 +10,36 @@ import { Construct } from 'constructs';
 import { LayerStack } from './layer.stack';
 
 export class AuthorizationStack extends Stack {
-  constructor(scope: Construct, id: string, layerStack: LayerStack, props?: StackProps) {
+
+  constructor(scope: Construct, id: string, layerStack: LayerStack, props: StackProps) {
     super(scope, id, props);
 
-    const PASSWORD: string = process.env.Shelenium || '';
+    const AUTH_USERNAME: string = process.env.AUTH_USERNAME || '';
+    const AUTH_PASSWORD: string = process.env[AUTH_USERNAME] || '';
 
     const basicAuthorizerLambda = new aws_lambda.Function(this, 'ArtRssShopBasicAuthorizer', {
       runtime: aws_lambda.Runtime.NODEJS_20_X,
-      handler: 'basic-auhorizer.basicAuthorizerHandler',
+      handler: 'basic-authorizer.basicAuthorizerHandler',
       code: aws_lambda.Code.fromAsset('./dist/authorization_service/handlers'),
-      memorySize: 512,
       environment: {
-        PASSWORD,
+        AUTH_USERNAME,
+        AUTH_PASSWORD,
       },
+      memorySize: 128,
+      timeout: Duration.seconds(10), 
       layers: [layerStack.sharedLayer],
+    });
+
+    
+    basicAuthorizerLambda.addPermission('APIGatewayInvokePermission', {
+      principal: new aws_iam.ServicePrincipal('apigateway.amazonaws.com'),
+      action: 'lambda:InvokeFunction',
+      sourceArn: `arn:aws:execute-api:${props.env!.region}:${props.env!.account}:*`,
+    });
+
+    new CfnOutput(this, 'AuthorizerLambdaArn', {
+      value: basicAuthorizerLambda.functionArn,
+      exportName: 'BasicAuthorizerLambdaArn',
     });
   }
 }

--- a/cdk/src/authorization.stack.ts
+++ b/cdk/src/authorization.stack.ts
@@ -1,0 +1,26 @@
+import {
+  aws_lambda,
+  Stack,
+  StackProps
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { LayerStack } from './layer.stack';
+
+export class AuthorizationStack extends Stack {
+  constructor(scope: Construct, id: string, layerStack: LayerStack, props?: StackProps) {
+    super(scope, id, props);
+
+    const PASSWORD: string = process.env.Shelenium || '';
+
+    const basicAuthorizerLambda = new aws_lambda.Function(this, 'ArtRssShopBasicAuthorizer', {
+      runtime: aws_lambda.Runtime.NODEJS_20_X,
+      handler: 'basic-auhorizer.basicAuthorizerHandler',
+      code: aws_lambda.Code.fromAsset('./dist/authorization_service/handlers'),
+      memorySize: 512,
+      environment: {
+        PASSWORD,
+      },
+      layers: [layerStack.sharedLayer],
+    });
+  }
+}

--- a/cdk/src/configs/default-cors-options.const.ts
+++ b/cdk/src/configs/default-cors-options.const.ts
@@ -13,3 +13,9 @@ export const getCorsMethodOptions: () => aws_apigateway.MethodOptions = () => ({
     }
   }],
 });
+
+export const authorizationHeaders = {
+  "Access-Control-Allow-Origin": "'*'",
+  "Access-Control-Allow-Headers": "'Content-Type, Authorization'",
+  "Access-Control-Allow-Methods": "'GET, PUT, OPTIONS'",
+};

--- a/cdk/src/import.stack.ts
+++ b/cdk/src/import.stack.ts
@@ -5,7 +5,7 @@ import { aws_s3, aws_s3_deployment, aws_apigateway, aws_lambda,
   Fn} from 'aws-cdk-lib';
 import { LayerStack } from './layer.stack';
 import * as path from 'path';
-import { defaultCorsPreflightOptions, getCorsMethodOptions } from './configs';
+import { authorizationHeaders, defaultCorsPreflightOptions, getCorsMethodOptions } from './configs';
 
 export class ImportStack extends Stack {
   constructor(scope: Construct, id: string, layerStack: LayerStack, props: StackProps) {
@@ -77,6 +77,32 @@ export class ImportStack extends Stack {
       defaultCorsPreflightOptions: {
         ...defaultCorsPreflightOptions,
         allowHeaders: ['Content-Type', 'Authorization'],
+      },
+    });
+
+    api.addGatewayResponse("UnauthorizedResponse", {
+      type: aws_apigateway.ResponseType.UNAUTHORIZED,
+      statusCode: "401",
+      responseHeaders: authorizationHeaders,
+      templates: {
+        "application/json": JSON.stringify({
+          message: "Unauthorized: Missing or invalid token",
+          errorType: "UNAUTHORIZED",
+          errorCode: 401,
+        }),
+      },
+    });
+    
+    api.addGatewayResponse("ForbiddenResponse", {
+      type: aws_apigateway.ResponseType.ACCESS_DENIED,
+      statusCode: "403",
+      responseHeaders: authorizationHeaders,
+      templates: {
+        "application/json": JSON.stringify({
+          message: "Forbidden: You do not have access to this resource",
+          errorType: "FORBIDDEN",
+          errorCode: 403,
+        }),
       },
     });
 

--- a/cdk/src/index.ts
+++ b/cdk/src/index.ts
@@ -1,3 +1,4 @@
+export * from './authorization.stack';
 export * from './import.stack';
 export * from './layer.stack';
 export * from './products.stack';

--- a/import_service/src/handlers/import-files.ts
+++ b/import_service/src/handlers/import-files.ts
@@ -8,7 +8,7 @@ const s3Client = new S3Client({ region: process.env.AWS_REGION });
 const headers = { 
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': '*',
-  'Access-Control-Allow-Methods': 'GET,PUT,POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, PUT, POST, DELETE, OPTIONS',
   'Access-Control-Allow-Credentials': true,
 };
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,10 +6,10 @@
     "paths": {
       "*": ["node_modules/*"],
     },
-    "rootDirs": ["import-service", "product-service", "cdk"],
+    "rootDirs": ["authorization_service", "import_service", "product_service", "cdk"],
     "noEmit": false,
   },
-  "include": ["import-service/src/**/*", "product-service/src/**/*", "cdk/src/**/*"],
+  "include": ["import_service/src/**/*", "product_service/src/**/*", "cdk/src/**/*"],
   "exclude": [
     "node_modules",
     "cdk.out",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./cdk" },
     { "path": "./import_service" },
-    { "path": "./product_service" }
+    { "path": "./product_service" },
+    { "path": "./authorization_service" }
   ]
 }

--- a/utils/generate-base-64-encoded.ts
+++ b/utils/generate-base-64-encoded.ts
@@ -1,5 +1,5 @@
-  const AUTH_USERNAME: string = 'Shelenium';
-  const AUTH_PASSWORD: string = 'TEST_PASSWORD';
+  const AUTH_USERNAME: string = 'userName';
+  const AUTH_PASSWORD: string = 'userPassword';
 
   const credentials = `${AUTH_USERNAME}:${AUTH_PASSWORD}`;
 

--- a/utils/generate-base-64-encoded.ts
+++ b/utils/generate-base-64-encoded.ts
@@ -1,0 +1,8 @@
+  const AUTH_USERNAME: string = 'Shelenium';
+  const AUTH_PASSWORD: string = 'TEST_PASSWORD';
+
+  const credentials = `${AUTH_USERNAME}:${AUTH_PASSWORD}`;
+
+  const base64Credentials = Buffer.from(credentials).toString('base64');
+
+  console.log(`Base64-Encoded Credentials for ${AUTH_USERNAME}:${AUTH_PASSWORD}:` , base64Credentials);


### PR DESCRIPTION
Current implementation: 100
Task 7.1 - Done
Task 7.2 - Done
Task 7.3 - Done
Task 7.4 - Done
Additional UI notifications +30.

[Link to app](https://d3eet7vshgnlxl.cloudfront.net/)
LocalStorage Key Name: **authorization_token** U2hlbGVuaXVtOlRFU1RfUEFTU1dPUkQ=
[Link to front PR](https://github.com/Shelenium/nodejs-aws-shop-react/pull/2/files)

![image](https://github.com/user-attachments/assets/7a33e7a7-efb6-43f5-95d5-932527c3638a)
![image](https://github.com/user-attachments/assets/020230c4-8271-4aea-a224-9f21eae3c0f9)
![image](https://github.com/user-attachments/assets/feadb233-b4da-43bf-a851-db578a1c45f9)
![image](https://github.com/user-attachments/assets/1fdb4ac9-f231-4315-8510-fcc8dbc53b94)
![image](https://github.com/user-attachments/assets/b0dd4e00-fa3f-4a0a-908d-fd481b1d95df)
![image](https://github.com/user-attachments/assets/d3eb30be-9bf3-410f-9a20-940d610bfee3)
![image](https://github.com/user-attachments/assets/f73a91e9-bf93-4ad2-b517-bc5985861ebd)
![image](https://github.com/user-attachments/assets/11a37f4f-a342-4cf8-acb9-d5147f309560)
![image](https://github.com/user-attachments/assets/b29ae8aa-2c4c-41c6-b112-7c6968b318fe)


authorization-service is added to the repo, has correct basicAuthorizer lambda and correct AWS CDK Stack
Import Service AWS CDK Stack has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
Client application is updated to send "Authorization: Basic authorization_token" header on import. 
Client should get authorization_token value from browser [localStorage]